### PR TITLE
Make regular expressions more restrictive

### DIFF
--- a/latex_completer.py
+++ b/latex_completer.py
@@ -62,8 +62,8 @@ class LatexCompleter( Completer ):
         super( LatexCompleter, self ).__init__( user_options )
         self._completion_target = 'none'
         self._main_directory    = None
-        self._cite_reg          = re.compile("cite.*\{")
-        self._ref_reg           = re.compile("ref\{|pageref\{")
+        self._cite_reg          = re.compile("\\\\[a-zA-Z]*cite[a-zA-Z]*\*?\{[^\s\}]*$")
+        self._ref_reg           = re.compile("\\\\[a-zA-Z]*ref\{[^\s\}]*$")
         self._files             = {}
         self._cached_data       = {}
         self._d_cache_hits      = 0


### PR DESCRIPTION
The regular expressions for \cite and \ref caused several issues where
completion was triggered outside of the tag (see #4). This commit makes
the regular expressions more accurate and more restrictive.

Resolves: #4
